### PR TITLE
Fix missing Menu import

### DIFF
--- a/invoice_spitter.py
+++ b/invoice_spitter.py
@@ -1,6 +1,6 @@
 import os
 import traceback
-from tkinter import Tk, StringVar, filedialog, messagebox
+from tkinter import Tk, Menu, StringVar, filedialog, messagebox
 from tkinter import ttk
 
 # External dependency: pypdf


### PR DESCRIPTION
## Summary
- import Menu from tkinter for GUI menu

## Testing
- `python -m py_compile invoice_spitter.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8430b07b88323b1c139df61837d2e