### PR TITLE
Revert responsive layout keep rounded widgets

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -135,14 +135,6 @@ class RoundedEntry(ttk.Frame):
     def delete(self, first, last=None) -> None:
         self.entry.delete(first, last)
 
-GITHUB_BG = "#1f2328"
-GITHUB_HEADER_BG = "#161b22"
-GITHUB_SURFACE = "#2d333b"
-GITHUB_TAB_ACTIVE = "#39424a"
-GITHUB_PRIMARY = "#2f81f7"
-GITHUB_FG = "#f0f6fc"
-
-
 class _BaseTab(ttk.Frame):
     """Common functionality shared by the individual notebook tabs."""
 


### PR DESCRIPTION
## Summary
- remove resize-aware entry and button layout logic to restore original fixed interface
- keep rounded button and entry components for consistent aesthetics

## Testing
- `python -m py_compile ui.py`
- `python ui.py` *(fails: ModuleNotFoundError: No module named 'pypdf')*
- `pip install pypdf` *(fails: Could not find a version that satisfies the requirement pypdf; Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b8551ad8a88323a24a37208eb26267