### PR TITLE
Resize file entry fields

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -104,7 +104,7 @@ class RoundedEntry(ttk.Frame):
         master,
         *,
         textvariable: StringVar | None = None,
-        width: int = 45,
+        width: int = 60,
         radius: int = 10,
     ) -> None:
         super().__init__(master)
@@ -114,14 +114,14 @@ class RoundedEntry(ttk.Frame):
         font = tkfont.Font()
         char_width = font.measure("0")
         w = char_width * width + 20
-        h = font.metrics("linespace") + 10
+        h = font.metrics("linespace") + 6
         _create_round_rect(self.canvas, 0, 0, w, h, radius, fill=GITHUB_SURFACE, outline="")
         self.entry = ttk.Entry(
             self,
             textvariable=textvariable,
             style="Rounded.TEntry",
         )
-        self.entry.place(x=10, y=5, width=w - 20, height=h - 10)
+        self.entry.place(x=10, y=3, width=w - 20, height=h - 6)
         self.configure(width=w, height=h)
         self.canvas.bind("<Configure>", self._resize)
 
@@ -129,7 +129,7 @@ class RoundedEntry(ttk.Frame):
         w, h = event.width, event.height
         self.canvas.delete("all")
         _create_round_rect(self.canvas, 0, 0, w, h, self.radius, fill=GITHUB_SURFACE, outline="")
-        self.entry.place(x=10, y=5, width=w - 20, height=h - 10)
+        self.entry.place(x=10, y=3, width=w - 20, height=h - 6)
 
     # Proxy common methods to the underlying entry
     def get(self) -> str:
@@ -191,7 +191,7 @@ class SplitTab(_BaseTab):
     # GUI construction ------------------------------------------------
     def _build_widgets(self) -> None:
         ttk.Label(self, text="Input PDF:").grid(row=0, column=0, sticky="w")
-        RoundedEntry(self, textvariable=self.input_var, width=45).grid(
+        RoundedEntry(self, textvariable=self.input_var, width=60).grid(
             row=0, column=1, padx=5, pady=2, sticky="we"
         )
         RoundedButton(self, text="Browse…", command=self._browse_input).grid(
@@ -199,7 +199,7 @@ class SplitTab(_BaseTab):
         )
 
         ttk.Label(self, text="Output folder:").grid(row=1, column=0, sticky="w")
-        RoundedEntry(self, textvariable=self.output_var, width=45).grid(
+        RoundedEntry(self, textvariable=self.output_var, width=60).grid(
             row=1, column=1, padx=5, pady=2, sticky="we"
         )
         RoundedButton(self, text="Choose…", command=self._browse_output).grid(
@@ -223,8 +223,8 @@ class SplitTab(_BaseTab):
         split_btn.grid(row=0, column=0, padx=4)
         clear_btn.grid(row=0, column=1, padx=4)
         self._setup_responsive_buttons(btn_frame, split_btn, clear_btn)
-
-        self.columnconfigure(1, weight=1)
+        self.grid_rowconfigure(self.grid_size()[1], weight=1)
+        self.columnconfigure(1, weight=0)
 
     # Widget callbacks ------------------------------------------------
     def _browse_input(self) -> None:
@@ -257,7 +257,7 @@ class SplitChosenTab(_BaseTab):
 
     def _build_widgets(self) -> None:
         ttk.Label(self, text="Input PDF:").grid(row=0, column=0, sticky="w")
-        RoundedEntry(self, textvariable=self.input_var, width=45).grid(
+        RoundedEntry(self, textvariable=self.input_var, width=60).grid(
             row=0, column=1, padx=5, pady=2, sticky="we"
         )
         RoundedButton(self, text="Browse…", command=self._browse_input).grid(
@@ -265,7 +265,7 @@ class SplitChosenTab(_BaseTab):
         )
 
         ttk.Label(self, text="Output folder:").grid(row=1, column=0, sticky="w")
-        RoundedEntry(self, textvariable=self.output_var, width=45).grid(
+        RoundedEntry(self, textvariable=self.output_var, width=60).grid(
             row=1, column=1, padx=5, pady=2, sticky="we"
         )
         RoundedButton(self, text="Choose…", command=self._browse_output).grid(
@@ -273,7 +273,7 @@ class SplitChosenTab(_BaseTab):
         )
 
         ttk.Label(self, text="Page selections:").grid(row=2, column=0, sticky="w")
-        RoundedEntry(self, textvariable=self.pages_var, width=45).grid(
+        RoundedEntry(self, textvariable=self.pages_var, width=60).grid(
             row=2, column=1, padx=5, pady=2, sticky="we"
         )
 
@@ -292,8 +292,8 @@ class SplitChosenTab(_BaseTab):
         split_btn.grid(row=0, column=0, padx=4)
         clear_btn.grid(row=0, column=1, padx=4)
         self._setup_responsive_buttons(btn_frame, split_btn, clear_btn)
-
-        self.columnconfigure(1, weight=1)
+        self.grid_rowconfigure(self.grid_size()[1], weight=1)
+        self.columnconfigure(1, weight=0)
 
     # Callbacks -------------------------------------------------------
     def _browse_input(self) -> None:
@@ -333,7 +333,7 @@ class MergeTab(_BaseTab):
 
     def _build_widgets(self) -> None:
         ttk.Label(self, text="PDFs to merge:").grid(row=0, column=0, sticky="w")
-        RoundedEntry(self, textvariable=self.input_var, width=45).grid(
+        RoundedEntry(self, textvariable=self.input_var, width=60).grid(
             row=0, column=1, padx=5, pady=2, sticky="we"
         )
         RoundedButton(self, text="Browse…", command=self._browse_input).grid(
@@ -341,7 +341,7 @@ class MergeTab(_BaseTab):
         )
 
         ttk.Label(self, text="Output PDF:").grid(row=1, column=0, sticky="w")
-        RoundedEntry(self, textvariable=self.output_var, width=45).grid(
+        RoundedEntry(self, textvariable=self.output_var, width=60).grid(
             row=1, column=1, padx=5, pady=2, sticky="we"
         )
         RoundedButton(self, text="Save As…", command=self._browse_output).grid(
@@ -363,8 +363,8 @@ class MergeTab(_BaseTab):
         merge_btn.grid(row=0, column=0, padx=4)
         clear_btn.grid(row=0, column=1, padx=4)
         self._setup_responsive_buttons(btn_frame, merge_btn, clear_btn)
-
-        self.columnconfigure(1, weight=1)
+        self.grid_rowconfigure(self.grid_size()[1], weight=1)
+        self.columnconfigure(1, weight=0)
 
     def _browse_input(self) -> None:
         paths = filedialog.askopenfilenames(


### PR DESCRIPTION
## Summary
- Widen default RoundedEntry to 60 characters
- Trim vertical padding so entry fields are shorter
- Use wider entries across all tabs

## Testing
- `python -m py_compile ui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8634515188323a33029e2e27b8639